### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/components/features/images/thumbnail.tsx
+++ b/frontend/src/components/features/images/thumbnail.tsx
@@ -10,7 +10,7 @@ export function Thumbnail({ src, size = "small" }: ThumbnailProps) {
     <img
       role="img"
       alt=""
-      src={src}
+      src={src.startsWith("blob:") ? src : ""}
       className={cn(
         "rounded object-cover",
         size === "small" && "w-[62px] h-[62px]",

--- a/frontend/src/components/features/images/upload-image-input.tsx
+++ b/frontend/src/components/features/images/upload-image-input.tsx
@@ -7,7 +7,12 @@ interface UploadImageInputProps {
 
 export function UploadImageInput({ onUpload, label }: UploadImageInputProps) {
   const handleUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event.target.files) onUpload(Array.from(event.target.files));
+    if (event.target.files) {
+      const validFiles = Array.from(event.target.files).filter((file) =>
+        file.type.startsWith("image/")
+      );
+      onUpload(validFiles);
+    }
   };
 
   return (


### PR DESCRIPTION
Potential fix for [https://github.com/hfpg2025/OpenHands/security/code-scanning/2](https://github.com/hfpg2025/OpenHands/security/code-scanning/2)

To fix the issue, we need to ensure that the `src` value passed to the `<img>` tag is safe. Since `URL.createObjectURL` is used to generate the `src` value, we should validate that the input to `URL.createObjectURL` is a valid `File` object. Additionally, we can add a fallback mechanism to handle cases where the `src` value might be manipulated or invalid.

1. Validate the uploaded files in `UploadImageInput` to ensure they are valid image files.
2. Add a fallback mechanism in the `Thumbnail` component to handle invalid or unsafe `src` values.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
